### PR TITLE
Implement fuzzy search and ranking

### DIFF
--- a/gnome-pass-search-provider.py
+++ b/gnome-pass-search-provider.py
@@ -97,7 +97,7 @@ class SearchPassService(dbus.service.Object):
                 matcher.set_seq1(path[:-4])
                 score = matcher.ratio()
 
-                if score >= 0.5:
+                if score > 0.0:
                     matches.append((score, path[:-4]))
 
         return [x[1] for x in sorted(matches, key=lambda x: x[0], reverse=True)]


### PR DESCRIPTION
The regex based method to find key matches does not work very well for deeper hierarchies and partial matching of the hierarchy levels. This approach uses the `SequenceMatcher` from the difflib module to compute a score for an entry and rank them accordingly. The cutoff threshold of 0.5 is debatable but works good enough for me.

This change also filters out all hidden file system entries to avoid traversing and evaluating Git repositories which are commonly used to store pass storages.