### PR TITLE
Stop the SearchProvider showing up as an app in activities

### DIFF
--- a/conf/org.gnome.Pass.SearchProvider.desktop
+++ b/conf/org.gnome.Pass.SearchProvider.desktop
@@ -7,3 +7,4 @@ Comment=GNOME Shell search provider for pass
 Terminal=false
 Type=Application
 OnlyShowIn=GNOME;
+NoDisplay=true;


### PR DESCRIPTION
After installing the search provider, a "Pass" entry was showing up as an application when searching in the activities interface with Gnome. Setting NoDisplay to true stops it showing up there.