### PR TITLE
Fix path to gpg-agent.conf in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo SYSCONFDIR=/etc DATADIR=/usr/share LIBDIR=/usr/lib LIBEXECDIR=/usr/lib ./in
 
 # Post-installation
 
-Recommended : set gpg agent to use pinentry-gnome3 by adding `pinentry-program /usr/bin/pinentry-gnome3` to `~/.gnupg/.gpg-agent.conf`.
+Recommended : set gpg agent to use pinentry-gnome3 by adding `pinentry-program /usr/bin/pinentry-gnome3` to `~/.gnupg/gpg-agent.conf`.
 
 If you are on Xorg, restart GNOME Shell by typing 'alt + f2' then entering 'r' as command.
 If you are on Wayland, you need to close and reopen your GNOME session.


### PR DESCRIPTION
Hey there! 
First of all, thank you for this awesome project! Using Pass and your search provider is the closest you can get to a nicely integrated password manager solution in Gnome at the moment.

I worked on a couple of small improvements for my personal use-case in my fork and thought I will open some PRs to contribute them back. However, of course, feel free to reject them if you don't consider them commonly useful.

This first one fixes the path to `gpg-agent.conf` in `README.md`. It should be `~/.gnupg/gpg-agent.conf` (without a leading `.` in the file name). For reference, e.g.: https://wiki.archlinux.org/index.php/GnuPG#Configuration_2