### PR TITLE
Fix desktop entry still showing up in application overview

### DIFF
--- a/conf/org.gnome.Pass.SearchProvider.desktop
+++ b/conf/org.gnome.Pass.SearchProvider.desktop
@@ -7,4 +7,4 @@ Comment=GNOME Shell search provider for pass
 Terminal=false
 Type=Application
 OnlyShowIn=GNOME;
-NoDisplay=true;
+NoDisplay=true


### PR DESCRIPTION
I'm running Gnome Shell v3.30.2 and the `Pass` desktop entry was still showing up in the shell application overview for me. 
Although #5 claims to have it fixed, for me it only works after this change.