### PR TITLE
Improve notifications style

### DIFF
--- a/gnome-pass-search-provider.py
+++ b/gnome-pass-search-provider.py
@@ -120,7 +120,7 @@ class SearchPassService(dbus.service.Object):
                 password,
                 dbus_interface='org.gnome.GPaste1'
             )
-            self.notify('Password {} copied to clipboard.'.format(name))
+            self.notify('Copied password to clipboard:', body='<b>{}</b>'.format(name))
         else:
             self.notify('Failed to copy password', body=error, error=True)
 
@@ -130,7 +130,7 @@ class SearchPassService(dbus.service.Object):
         if pass_cmd.returncode:
             self.notify('Failed to copy password!', error=True)
         else:
-            self.notify('Password {} copied to clipboard.'.format(name))
+            self.notify('Copied password to clipboard:', body='<b>{}</b>'.format(name))
 
     def send_password_to_clipboard(self, name):
         try:
@@ -148,7 +148,7 @@ class SearchPassService(dbus.service.Object):
             ).Notify(
                 'Pass',
                 0,
-                '',
+                'dialog-password',
                 message,
                 body,
                 '',


### PR DESCRIPTION
This PR changes the notification style:

* The password entry name is moved to the message body and boldified to better stand out from the remaining notification content.
* A notification icon is specified. It uses `dialog-password`, which is present in the default Gnome icon theme. I tested it with a bunch of icon themes I have installed on my machine and the icon looks decent for all of them. This should be an improvement over the default icon that is shown currently.

Example (using `Paper` icon theme and default shell theme):
![bildschirmfoto vom 2019-01-01 15-33-47](https://user-images.githubusercontent.com/1223891/50573802-f078f000-0dda-11e9-8553-701c86806c33.png)
