### PR TITLE
Show icon for individual search results

### DIFF
--- a/gnome-pass-search-provider.py
+++ b/gnome-pass-search-provider.py
@@ -72,7 +72,7 @@ class SearchPassService(dbus.service.Object):
 
     @dbus.service.method(in_signature='as', out_signature='aa{sv}', **sbn)
     def GetResultMetas(self, ids):
-        return [dict(id=id, name=id,) for id in ids]
+        return [dict(id=id, name=id, gicon="password-manager") for id in ids]
 
     @dbus.service.method(in_signature='asas', out_signature='as', **sbn)
     def GetSubsearchResultSet(self, previous_results, new_terms):


### PR DESCRIPTION
Currently, the pass search provider stands out as the only search provider in my shell that does not display icons for its individual search results. 

This PR specifies an icon to display for each search result. It uses the same icon as the application entry (`password-manager`), which seems to be what most apps do in case they don't have any other more specific icon to show for their result items.

Example (using `Paper` icon theme):

![bildschirmfoto vom 2019-01-01 15-45-43](https://user-images.githubusercontent.com/1223891/50573909-228b5180-0ddd-11e9-88ad-93b43df69973.png)

In case the icon theme does not support the icon, it is left blank.