### PR TITLE
Add note about Debian package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Names of passwords will show up in GNOME Shell searches, choosing one will copy 
 ## Arch Linux
 Install `gnome-pass-search-provider-git` from the AUR.
 
+## Debian (buster-backports and later)
+Install `gnome-pass-search-provider` through APT.
+
 ## Manual
 
 Ensure that python>=3.5 and python-gobject are installed on your system and that pass is setup.


### PR DESCRIPTION
Today, I uploaded a gnome-pass-search-provider package to the official Debian repositories and expect it to land in Debian unstable shortly. Once it migrates to bullseye (testing), I will upload to buster-backports as well.

I will ping this PR once the package was accepted.