### PR TITLE
start together with org.gnome.GPaste.service

### DIFF
--- a/conf/org.gnome.Pass.SearchProvider.service.systemd
+++ b/conf/org.gnome.Pass.SearchProvider.service.systemd
@@ -1,5 +1,6 @@
 [Unit]
 Description=Pass search provider for GNOME Shell daemon
+Wants=org.gnome.GPaste.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
- this is a weak dependency and will still succeed if GPaste is not available
  (also see [systemd.unit(5)](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=))
- avoids having to manually start GPaste
- also see https://github.com/Keruspe/GPaste/pull/323