### PR TITLE
Use RapidFuzz in Fedora 43

### DIFF
--- a/gnome-pass-search-provider.py
+++ b/gnome-pass-search-provider.py
@@ -36,8 +36,12 @@ try:
     from thefuzz import fuzz
     from thefuzz import process
 except ModuleNotFoundError:
-    from fuzzywuzzy import fuzz
-    from fuzzywuzzy import process
+    try:
+        from fuzzywuzzy import fuzz
+        from fuzzywuzzy import process
+    except ModuleNotFoundError:
+        from rapidfuzz import fuzz
+        from rapidfuzz import process
 from gi.repository import GLib
 
 # Convenience shorthand for declaring dbus interface methods.

--- a/gnome-pass-search-provider.spec
+++ b/gnome-pass-search-provider.spec
@@ -9,8 +9,12 @@ Requires:       gnome-shell
 Requires:       pass
 Requires:       python3-gobject
 Requires:       python3-dbus
-Requires:       python3-fuzzywuzzy
 Requires:       python3-Levenshtein
+%if 0%{?fedora} >= 43
+Requires:       python3-rapidfuzz
+%else
+Requires:       python3-fuzzywuzzy
+%endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %global debug_package %{nil}


### PR DESCRIPTION
Fedora 43 does not package fuzzywuzzy anymore, nor thefuzz. This MR adds support for using [RapidFuzz](https://github.com/rapidfuzz/RapidFuzz) instead.

I have no experience with rpm packaging, but I've tested the spec locally and it worked for me.

Relates to / fixes #29.